### PR TITLE
Improve Form1 backup handling

### DIFF
--- a/pharma_manage/Form1.Designer.cs
+++ b/pharma_manage/Form1.Designer.cs
@@ -200,6 +200,7 @@
             this.timer2 = new System.Windows.Forms.Timer(this.components);
             this.timer_for_deleting_temp = new System.Windows.Forms.Timer(this.components);
             this.backgroundWorker_delete_temp = new System.ComponentModel.BackgroundWorker();
+            this.backgroundWorker_backup = new System.ComponentModel.BackgroundWorker();
             this.timer_backup = new System.Windows.Forms.Timer(this.components);
             this.button21 = new System.Windows.Forms.Button();
             this.timer_backup_to_mail = new System.Windows.Forms.Timer(this.components);
@@ -1685,7 +1686,7 @@
             // timer2
             // 
             this.timer2.Enabled = true;
-            this.timer2.Interval = 2000;
+            this.timer2.Interval = 10000;
             this.timer2.Tick += new System.EventHandler(this.timer2_Tick);
             // 
             // timer_for_deleting_temp
@@ -1703,9 +1704,13 @@
             this.timer_backup.Enabled = true;
             this.timer_backup.Interval = 3600000;
             this.timer_backup.Tick += new System.EventHandler(this.timer_backup_Tick);
-            // 
+            //
+            // backgroundWorker_backup
+            //
+            this.backgroundWorker_backup.DoWork += new System.ComponentModel.DoWorkEventHandler(this.backgroundWorker_backup_DoWork);
+            //
             // button21
-            // 
+            //
             resources.ApplyResources(this.button21, "button21");
             this.button21.Name = "button21";
             this.button21.UseVisualStyleBackColor = true;
@@ -2233,6 +2238,7 @@
         private System.Windows.Forms.ToolStripMenuItem إحصائياتالأقساطToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem طباعةالجردToolStripMenuItem;
         private System.ComponentModel.BackgroundWorker backgroundWorker1_google_drive;
+        private System.ComponentModel.BackgroundWorker backgroundWorker_backup;
         private System.Windows.Forms.ProgressBar progressBar1;
     }
 }

--- a/pharma_manage/Form1.cs
+++ b/pharma_manage/Form1.cs
@@ -2995,8 +2995,21 @@ namespace pharma_manage
         string ph_name;
         private void timer_backup_Tick(object sender, EventArgs e)
         {
+            try
+            {
+                if (!backgroundWorker_backup.IsBusy)
+                {
+                    backgroundWorker_backup.RunWorkerAsync();
+                }
+            }
+            catch { }
+
+        }
+
+        private void backgroundWorker_backup_DoWork(object sender, DoWorkEventArgs e)
+        {
             get_partition();
-            
+
             ras_mal_method();
 
             string un = "";
@@ -3112,7 +3125,7 @@ namespace pharma_manage
                      System.IO.File.Delete(path.ToString());
                  }
 
-                
+
                 // MessageBox.Show("تم انشاء نسخه احتياطية لقاعدة البيانات  بنجاح ", "تنبيه", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- slow down the category refresh timer
- run database backups on a background worker to keep the UI responsive

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68471c9d343c832fa8f0558adab01d13